### PR TITLE
fix: add health check for worker service

### DIFF
--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -112,6 +112,8 @@ services:
         condition: service_healthy
       server:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test:
         - CMD-SHELL

--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -120,7 +120,7 @@ services:
         - 'pgrep -f "worker:prod" > /dev/null || exit 1'
       interval: 10s
       timeout: 10s
-      retries: 5
+      retries: 10
       start_period: 30s
     restart: always
   db:

--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -112,6 +112,14 @@ services:
         condition: service_healthy
       server:
         condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'pgrep -f "worker:prod" || exit 1'
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: always
   db:
     image: 'postgres:16-alpine'

--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -115,8 +115,8 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'pgrep -f "worker:prod" || exit 1'
-      interval: 30s
+        - 'pgrep -f "worker:prod" > /dev/null && redis-cli -h redis ping > /dev/null || exit 1'
+      interval: 10s
       timeout: 10s
       retries: 5
       start_period: 30s

--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -117,7 +117,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'pgrep -f "worker:prod" > /dev/null && redis-cli -h redis ping > /dev/null || exit 1'
+        - 'pgrep -f "worker:prod" > /dev/null || exit 1'
       interval: 10s
       timeout: 10s
       retries: 5

--- a/twenty-docker-compose.yaml
+++ b/twenty-docker-compose.yaml
@@ -119,7 +119,7 @@ services:
         - CMD-SHELL
         - 'pgrep -f "worker:prod" > /dev/null || exit 1'
       interval: 10s
-      timeout: 10s
+      timeout: 5s
       retries: 10
       start_period: 30s
     restart: always


### PR DESCRIPTION
Add missing health check configuration for the worker service to monitor the worker:prod process. This ensures Docker properly tracks the worker's health status and can restart it if needed.

Fixes: twentyhq/twenty#5219
Ref: https://github.com/twentyhq/twenty/discussions/5219#discussioncomment-15922144

Test:
<img width="1570" height="974" alt="image" src="https://github.com/user-attachments/assets/1fd8357c-1893-4e40-9c99-f8d1083fc35a" />
